### PR TITLE
Moves telemetry code into subsystem periodic functions

### DIFF
--- a/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/commands/DepositorCommand.java
+++ b/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/commands/DepositorCommand.java
@@ -24,7 +24,6 @@ public class DepositorCommand extends CommandBase {
 
     @Override
     public void execute() {
-        m_depositor.printBasketPose();
-        m_depositor.printVerticalPose();
+        //TODO make depositor go up and down
     }
 }

--- a/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/commands/IntakeCommand.java
+++ b/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/commands/IntakeCommand.java
@@ -23,7 +23,6 @@ public class IntakeCommand extends CommandBase {
 
     @Override
     public void execute() {
-        m_intake.printHorizontalPose();
-        m_intake.printPivotPose();
+        //TODO make intake go in and out
     }
 }

--- a/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/opmodes/teleop/MainDrive.java
+++ b/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/opmodes/teleop/MainDrive.java
@@ -1,6 +1,7 @@
 package org.firstinspires.ftc.teamcode.opmodes.teleop;
 
 import com.arcrobotics.ftclib.command.CommandOpMode;
+import com.arcrobotics.ftclib.command.RunCommand;
 import com.qualcomm.robotcore.eventloop.opmode.TeleOp;
 
 import org.firstinspires.ftc.teamcode.commands.DepositorCommand;
@@ -36,5 +37,8 @@ public class MainDrive extends CommandOpMode {
                 ()->this.gamepad1.dpad_down));
 
         register(drive, intake, depositor);
+
+        // Automatically updates telemetry
+        schedule(new RunCommand(telemetry::update));
     }
 }

--- a/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/subsystems/Depositor.java
+++ b/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/subsystems/Depositor.java
@@ -22,6 +22,12 @@ public class Depositor extends SubsystemBase {
         this.telemetry = telemetry;
     };
 
+    @Override
+    public void periodic() {
+        telemetry.addData("Vertical Position", vertical.getCurrentPosition());
+        telemetry.addData("Basket Position", basket.getAngle());
+    }
+
     private void verticalToPos(double targetPos) {
         vertical.setRunMode(Motor.RunMode.RawPower);
         double kP = Constants.depositorVerticalKP;
@@ -67,12 +73,5 @@ public class Depositor extends SubsystemBase {
 
     public void basketToHome() {
         basket.turnToAngle(Constants.depositorBasketToHomeAngle);
-    }
-
-    public void printVerticalPose() {
-        telemetry.addData("Vertical Position", vertical.getCurrentPosition());
-    }
-    public void printBasketPose() {
-        telemetry.addData("Basket Position", basket.getAngle());
     }
 }

--- a/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/subsystems/Intake.java
+++ b/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/subsystems/Intake.java
@@ -26,6 +26,12 @@ public class Intake extends SubsystemBase {
         this.telemetry = telemetry;
     };
 
+    @Override
+    public void periodic() {
+        telemetry.addData("Horizontal Position", horizontal.getAngle());
+        telemetry.addData("Pivot Position", pivot.getAngle());
+    }
+
     private void horizontalToPos(double targetPos) {
         horizontal.turnToAngle(targetPos);
     }
@@ -80,15 +86,5 @@ public class Intake extends SubsystemBase {
             }
 
         }
-    }
-
-    // Tests
-
-    public void printHorizontalPose() {
-        telemetry.addData("Horizontal Position", horizontal.getAngle());
-    }
-
-    public void printPivotPose() {
-        telemetry.addData("Pivot Position", pivot.getAngle());
     }
 }


### PR DESCRIPTION
For prints instead of making bespoke functions that only have a single LOC. You can collate them into a subsystems `periodic` function. 

When a subsystem is registered via the opmode's `register(...)` function or via a subsystems `.setDefaultCommand()` function the periodic function is called every so often. This makes it a good candidate for printing telemetry, updating position, etc. 

We can also schedule functions to run periodically in a opmode. In the `MainDrive` opmode, there is a `schedule(new RunCommand(telemetry::update))` line. This tells the robot to update the robots telemetry every update cycle. 

You don't need to merge this if you don't want to, but you may find this methodology more elegant than putting print statements in commands. 